### PR TITLE
Add `githubActions/regexManagers` preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,6 +4,7 @@
     "config:base",
     "github>Turbo87/renovate-config:automergeCaretConstraint",
     "github>Turbo87/renovate-config:commitTopics",
+    "github>Turbo87/renovate-config//githubActions/regexManagers",
     ":automergeLinters",
     ":automergeTesters",
     ":dependencyDashboard",

--- a/githubActions/regexManagers.json
+++ b/githubActions/regexManagers.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Update annotated environment variables in GitHub Actions files",
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "^.github/workflows/[^\\.]+\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-0-9]+?))?\\s  .+?_VERSION\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is similar to https://docs.renovatebot.com/presets-regexManagers/#regexmanagersdockerfileversions, but for GitHub Actions files.


### Example:

```
env:
  # renovate: datasource=npm depName=pnpm
  PNPM_VERSION: 7.14.0
```