### PR TITLE
renovate: Use weekly update schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>Turbo87/renovate-config"
+    "local>Turbo87/renovate-config",
+    "schedule:weekly"
   ]
 }


### PR DESCRIPTION
There is no need for us to keep this up-to-date as soon as possible, especially given how often `renovate` itself publishes releases...