### PR TITLE
CI: Use Node.js 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v3.6.0
         with:
-          node-version: 14.x
+          node-version: 18.x
           cache: pnpm
 
       - run: pnpm install


### PR DESCRIPTION
It looks like renovatebot v35 is no longer compatible with Node.js 14