### PR TITLE
rust/updateToolchain matches files in sub-directories

### DIFF
--- a/rust/updateToolchain.json
+++ b/rust/updateToolchain.json
@@ -3,7 +3,7 @@
   "description": "Upgrades the `channel` field in the `rust-toolchain.toml` file",
   "regexManagers": [
     {
-      "fileMatch": ["^rust-toolchain\\.toml?$"],
+      "fileMatch": ["(^|/)rust-toolchain\\.toml?$"],
       "matchStrings": [
         "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+(\\.\\d+)?)\""
       ],


### PR DESCRIPTION
Plagarising the regexp from [renovate's fileMatch documentation](https://docs.renovatebot.com/configuration-options/#filematch).